### PR TITLE
Add support for 'main' branch in build workflow configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
 
 name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
         image: swiss-army-knife
-        tag: ${{ github.event.release.tag_name }}
+        tag: ${{ github.event.release.tag_name }},latest
         public-repo: rancherlabs
         public-username: ${{ env.DOCKER_USERNAME }}
         public-password: ${{ env.DOCKER_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Get git commit hash
+GIT_COMMIT := $(shell git rev-parse --short HEAD)
+
+# Try to get the tag, if it exists
+GIT_TAG := $(shell git describe --tags --exact-match HEAD 2>/dev/null)
+
+# Set TAG based on whether a git tag exists
+ifdef GIT_TAG
+    # We're on a tagged commit, use the tag
+    TAG := $(GIT_TAG)
+else
+    # Not on a tag, use build-{commit} format
+    TAG := build-$(GIT_COMMIT)
+endif
+
+# Default target
+.PHONY: all
+all: build
+
+# Build target
+.PHONY: build
+build:
+	go build -o echo-server main.go
+
+# Log target - outputs variables for CI/CD
+.PHONY: log
+log:
+	@echo "TAG=$(TAG)"
+	@echo "BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")"
+	@echo "GIT_COMMIT=$(GIT_COMMIT)"


### PR DESCRIPTION
We need to trigger GH Actions on the main branch instead of the master branch.