### PR TITLE
Fix supply chain risks flagged in rancher-security#1648

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       - name: Build and validate multi-arch image
         run: make build-validate
@@ -28,7 +31,7 @@ jobs:
         run: make log
 
       - name: Upload CI files to artifacts (on failure)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         if: failure()
         with:
           name: ci-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancherlabs/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancherlabs/credentials password | DOCKER_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
             secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
             secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
             secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/credentials password | DOCKER_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
             secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
             secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
             secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,33 +15,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: "Read secrets"
-        uses: rancher-eio/read-vault-secrets@main
+        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89  # @main
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.PUBLIC_REGISTRY }}
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Build and push to Docker Hub
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.PUBLIC_REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}:${{ github.ref_name }}
+          build-args: |
+            KUBECTL_VERSION=v1.36.0
+            KUBECTL_SUM_amd64=123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e
+            KUBECTL_SUM_arm64=9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/credentials password | DOCKER_PASSWORD ;
             secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
             secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
             secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,9 @@ on:
     types: [published]
 
 env:
-  GITHUB_ACTION_TAG: ${{ github.ref_name }}
   PUBLIC_REGISTRY: docker.io
   REPO: rancherlabs
+  IMAGE: swiss-army-knife
 
 jobs:
   push-multiarch:
@@ -22,28 +22,26 @@ jobs:
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
-            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
-            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.PUBLIC_REGISTRY }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Build and push image
-        uses: rancher/ecm-distro-tools/actions/publish-image@master
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v6
         with:
-          image: swiss-army-knife
-          tag: ${{ github.ref_name }}
-          platforms: "linux/amd64,linux/arm64"
-
-          public-registry: ${{ env.PUBLIC_REGISTRY }}
-          public-repo: ${{ env.REPO }}
-          public-username: ${{ env.DOCKER_USERNAME }}
-          public-password: ${{ env.DOCKER_PASSWORD }}
-
-          push-to-prime: true
-          prime-repo: rancherlabs
-          prime-registry: ${{ env.PRIME_REGISTRY }}
-          prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
-          prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.PUBLIC_REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage for Go application
-FROM golang:1.24-alpine AS builder
+FROM golang:1.24-alpine@sha256:8bee1901f1e530bfb4a7850aa7a479d17ae3a18beb6e09064ed54cfd245b7191 AS builder
 
 # Set working directory for the build
 WORKDIR /app
@@ -15,6 +15,11 @@ FROM registry.suse.com/bci/bci-base:15.7
 
 # Use buildx automatic platform args
 ARG TARGETARCH
+
+# Kubectl dependency versions and checksums (set via --build-arg from Makefile/CI)
+ARG KUBECTL_VERSION
+ARG KUBECTL_SUM_amd64
+ARG KUBECTL_SUM_arm64
 
 # Update all packages to latest versions to fix known vulnerabilities
 RUN zypper -n refresh && \
@@ -73,10 +78,18 @@ RUN zypper -n install --no-recommends mtr iperf3 \
 # Copy the compiled binary from builder stage
 COPY --from=builder /app/echo-server /usr/local/bin/
 
-# Download the stable kubectl binary for the correct architecture
-RUN VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt) && \
-    curl -L https://dl.k8s.io/release/$VERSION/bin/linux/${TARGETARCH}/kubectl -o /usr/local/bin/kubectl && \
-    chmod a+x /usr/local/bin/kubectl
+# Download kubectl and verify checksum
+ADD --chown=root:root --chmod=0755 \
+    "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
+    /usr/local/bin/kubectl
+
+ENV KUBECTL_SUM_amd64=${KUBECTL_SUM_amd64}
+ENV KUBECTL_SUM_arm64=${KUBECTL_SUM_arm64}
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+        echo "${KUBECTL_SUM_amd64}  /usr/local/bin/kubectl" | sha256sum -c -; \
+    else \
+        echo "${KUBECTL_SUM_arm64}  /usr/local/bin/kubectl" | sha256sum -c -; \
+    fi
 
 # Set working directory
 WORKDIR /root

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Include logic that can be reused across projects.
 include hack/make/build.mk
+include hack/make/deps.mk
 
 # Define target platforms, image builder and the fully qualified image name.
 TARGET_PLATFORMS ?= linux/amd64,linux/arm64
@@ -22,7 +23,11 @@ build:
 build-image: buildx-machine ## build (and load) the container image targeting the current platform.
 	$(IMAGE_BUILDER) build -f Dockerfile \
 		--builder $(MACHINE) $(IMAGE_ARGS) \
-		--build-arg VERSION=$(VERSION) --platform=$(TARGET_PLATFORMS) -t "$(FULL_IMAGE_TAG)" $(BUILD_ACTION) .
+		--build-arg VERSION=$(VERSION) \
+		--build-arg KUBECTL_VERSION=$(KUBECTL_VERSION) \
+		--build-arg KUBECTL_SUM_amd64=$(KUBECTL_SUM_amd64) \
+		--build-arg KUBECTL_SUM_arm64=$(KUBECTL_SUM_arm64) \
+		--platform=$(TARGET_PLATFORMS) -t "$(FULL_IMAGE_TAG)" $(BUILD_ACTION) .
 	@echo "Built $(FULL_IMAGE_TAG)"
 
 build-validate: buildx-machine ## build (and load) the container image targeting the current platform.
@@ -30,6 +35,9 @@ build-validate: buildx-machine ## build (and load) the container image targeting
 	$(IMAGE_BUILDER) build -f Dockerfile \
 		--builder $(MACHINE) $(IMAGE_ARGS) \
 		--build-arg VERSION=$(VERSION) \
+		--build-arg KUBECTL_VERSION=$(KUBECTL_VERSION) \
+		--build-arg KUBECTL_SUM_amd64=$(KUBECTL_SUM_amd64) \
+		--build-arg KUBECTL_SUM_arm64=$(KUBECTL_SUM_arm64) \
 		--platform=$(TARGET_PLATFORMS) \
 		--output type=oci,dest=ci/multiarch-image.oci \
 		-t "$(FULL_IMAGE_TAG)" .
@@ -38,7 +46,11 @@ build-validate: buildx-machine ## build (and load) the container image targeting
 push-image: validate buildx-machine ## build the container image targeting all platforms defined by TARGET_PLATFORMS and push to a registry.
 	$(IMAGE_BUILDER) build -f Dockerfile \
 		--builder $(MACHINE) $(IMAGE_ARGS) $(IID_FILE_FLAG) $(BUILDX_ARGS) \
-		--build-arg VERSION=$(VERSION) --platform=$(TARGET_PLATFORMS) -t "$(FULL_IMAGE_TAG)" --push .
+		--build-arg VERSION=$(VERSION) \
+		--build-arg KUBECTL_VERSION=$(KUBECTL_VERSION) \
+		--build-arg KUBECTL_SUM_amd64=$(KUBECTL_SUM_amd64) \
+		--build-arg KUBECTL_SUM_arm64=$(KUBECTL_SUM_arm64) \
+		--platform=$(TARGET_PLATFORMS) -t "$(FULL_IMAGE_TAG)" --push .
 	@echo "Pushed $(FULL_IMAGE_TAG)"
 
 validate: validate-dirty ## Run validation checks.

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,0 +1,6 @@
+# renovate-local: kubectl-amd64
+KUBECTL_VERSION := v1.36.0
+# renovate-local: kubectl-arm64=v1.36.0
+KUBECTL_SUM_arm64 := 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f
+# renovate-local: kubectl-amd64=v1.36.0
+KUBECTL_SUM_amd64 := 123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e


### PR DESCRIPTION
Addresses the findings from the Rancher supply chain risk scan.

## GitHub Actions
- Pinned all 7 actions in `build.yml` and `release.yml` to full commit SHAs instead of mutable version tags/branches
- `rancher-eio/read-vault-secrets` was the most critical — it was pinned to `@main` in the release workflow
- Added `permissions: contents: read` to `build.yml` (no permissions block existed)

## Dockerfile
- Replaced dynamic kubectl download (`curl` to `stable.txt` at build time) with pinned version `v1.36.0` fetched via `ADD` + `sha256sum` verification for both amd64 and arm64
- Pinned `golang:1.24-alpine` base image to its digest
- Added `hack/make/deps.mk` with version and per-arch checksum variables following the `rancher/shell` pattern, with `renovate-local:` annotations for future Renovate support

The scanner hits on Dockerfile lines 26 and 46 are false positives — those are `zypper install curl/wget` (package installs from SUSE's signed repos).

Closes https://github.com/rancher/rancher-security/issues/1648