### PR TITLE
fix: add latest tag to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.PUBLIC_REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}:${{ github.ref_name }}
+          tags: |
+            ${{ env.PUBLIC_REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}:${{ github.ref_name }}
+            ${{ env.PUBLIC_REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}:latest
           build-args: |
             KUBECTL_VERSION=v1.36.0
             KUBECTL_SUM_amd64=123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e


### PR DESCRIPTION
## Summary

- Closes #13
- The `latest` tag on `docker.io/rancherlabs/swiss-army-knife` was not being updated on release
- Multi-arch support (`linux/amd64,linux/arm64`) already existed in the build infra; this change ensures `latest` is pushed alongside the version tag on every GitHub release

## Changes

- `.github/workflows/release.yml`: add `latest` as a second tag in the `Build and push to Docker Hub` step

## Test plan

- [ ] Create a GitHub Release and confirm `docker pull rancherlabs/swiss-army-knife:latest` resolves
- [ ] Verify `docker manifest inspect docker.io/rancherlabs/swiss-army-knife:latest` shows both `linux/amd64` and `linux/arm64`
- [ ] Confirm the versioned tag (e.g. `v2.0-rc7`) is still also pushed