### PR TITLE
Add logs collector, revise kubectl download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,3 @@ jobs:
           tags: |
             ${{ env.PUBLIC_REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}:${{ github.ref_name }}
             ${{ env.PUBLIC_REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}:latest
-          build-args: |
-            KUBECTL_VERSION=v1.36.0
-            KUBECTL_SUM_amd64=123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e
-            KUBECTL_SUM_arm64=9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,17 +79,12 @@ RUN zypper -n install --no-recommends mtr iperf3 \
 COPY --from=builder /app/echo-server /usr/local/bin/
 
 # Download kubectl and verify checksum
-ADD --chown=root:root --chmod=0755 \
-    "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
-    /usr/local/bin/kubectl
-
-ENV KUBECTL_SUM_amd64=${KUBECTL_SUM_amd64}
-ENV KUBECTL_SUM_arm64=${KUBECTL_SUM_arm64}
-RUN if [ "${TARGETARCH}" = "amd64" ]; then \
-        echo "${KUBECTL_SUM_amd64}  /usr/local/bin/kubectl" | sha256sum -c -; \
-    else \
-        echo "${KUBECTL_SUM_arm64}  /usr/local/bin/kubectl" | sha256sum -c -; \
-    fi
+RUN KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt) && \
+    curl -sLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" && \
+    curl -sLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl.sha256" && \
+    echo "$(cat kubectl.sha256) kubectl" | sha256sum --check && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+    rm kubectl*
 
 # Set working directory
 WORKDIR /root
@@ -99,6 +94,11 @@ RUN mkdir /root/.kube
 
 # Setup kubectl autocompletion, aliases, and profiles
 RUN kubectl completion bash > /etc/bash_completion.d/kubectl
+
+# Add logs collector script
+ADD --chown=root:root --chmod=0755 \
+    https://raw.githubusercontent.com/rancherlabs/support-tools/refs/heads/master/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh \
+    /usr/local/bin/rancher2_logs_collector.sh
 
 # Default command
 CMD ["/usr/local/bin/echo-server"]


### PR DESCRIPTION
- Add logs collector script for use in pods (related: https://github.com/rancherlabs/support-tools/issues/430)
- Use available version and checksum for kubectl download