### PR TITLE
Add troubleshooting tools, revise zypper install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o echo-server main.go
 
 # Final stage
-FROM registry.suse.com/bci/bci-base:15.7
+FROM registry.suse.com/bci/bci-base:15.6
 
 # Use buildx automatic platform args
 ARG TARGETARCH
@@ -22,58 +22,44 @@ ARG KUBECTL_SUM_amd64
 ARG KUBECTL_SUM_arm64
 
 # Update all packages to latest versions to fix known vulnerabilities
-RUN zypper -n refresh && \
+RUN source /etc/os-release && \
+    zypper addrepo https://download.opensuse.org/repositories/network:utilities/${VERSION_ID}/network:utilities.repo && \
+    zypper -n --gpg-auto-import-keys refresh && \
     zypper -n update -y && \
-    zypper -n clean -a
-
-# Install required packages from standard repositories and perform cleanup
-RUN zypper -n install --no-recommends \
-    curl \
-    ca-certificates \
-    openssl \
-    ethtool \
-    iproute2 \
-    ipset \
-    iptables \
-    iputils \
-    jq \
-    kmod \
-    less \
-    net-tools \
-    bind-utils \
-    psmisc \
-    socat \
-    tcpdump \
-    telnet \
-    traceroute \
-    tree \
-    vim-small \
-    wget \
-    bash-completion \
-    gcc \
-    gcc-c++ \
-    make \
-    automake \
-    autoconf \
-    gawk \
-    libtool && \
+    zypper -n install --no-recommends \
+        curl \
+        ca-certificates \
+        ethtool \
+        iproute2 \
+        ipset \
+        iptables \
+        iputils \
+        jq \
+        less \
+        net-tools \
+        bind-utils \
+        psmisc \
+        socat \
+        tcpdump \
+        telnet \
+        traceroute \
+        tree \
+        vim-small \
+        wget \
+        bash-completion \
+        gawk \
+        procps \
+        lsof \
+        strace \
+        sysstat \
+        iotop \
+        nmap \
+        mtr \
+        iperf \
+        netcat-openbsd \
+        conntrack-tools && \
     zypper -n clean -a && \
     rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
-
-# Install additional networking tools that may require alternative packages
-RUN zypper -n install --no-recommends \
-    ncat \
-    || zypper -n install --no-recommends netcat \
-    || echo "Warning: netcat not available, using built-in networking tools"
-
-# Install conntrack if available (may not be in all SUSE repositories)
-RUN zypper -n install --no-recommends conntrack \
-    || echo "Warning: conntrack not available"
-
-# Install mtr and iperf if available 
-RUN zypper -n install --no-recommends mtr iperf3 \
-    || zypper -n install --no-recommends mtr iperf \
-    || echo "Warning: mtr/iperf not available"
 
 # Copy the compiled binary from builder stage
 COPY --from=builder /app/echo-server /usr/local/bin/


### PR DESCRIPTION
- Use bci-base:15.6 for wider package support
- Combine all zypper commands to create a single layer
- add packages: procps, lsof, strace, sysstat, iotop, nmap, mtr, iperf, netcat, conntrack
- remove gcc, autoconf, libtool and make, as these don't appear to be needed

This adds tools, and hopefully reduces the container image size